### PR TITLE
Better support for boolean values

### DIFF
--- a/lib/simple_show/base.rb
+++ b/lib/simple_show/base.rb
@@ -67,5 +67,9 @@ module SimpleShow
         [SimpleShow.value_prefix, value, SimpleShow.value_suffix].compact.join.html_safe
       end
     end
+
+    def object
+      @record
+    end
   end
 end


### PR DESCRIPTION
Previously, a false boolean value would cause the SimpleShow::Base#value method to skip past the application of helpers and formats.  With this small code change, boolean values of false will be handled correctly.
