### PR TITLE
Include show field type as a CSS class

### DIFF
--- a/lib/simple_show/base.rb
+++ b/lib/simple_show/base.rb
@@ -63,7 +63,7 @@ module SimpleShow
         end
       end
 
-      field_type = (@record.class.columns_hash[attr.to_s].type rescue nil)
+      field_type = @record.class.columns_hash[attr.to_s].instance_variable_get(:@type)
       @binding.content_tag(SimpleShow.value_tag, :class => [SimpleShow.value_class, field_type].compact) do
         [SimpleShow.value_prefix, value, SimpleShow.value_suffix].compact.join.html_safe
       end


### PR DESCRIPTION
Hi Philip,

This change is actually just one commit, regardless of the way GitHub is saying it is 4 commits.

This change adds an extra CSS class to the shown fields.  The extra CSS class is just the column type of the field.  The motivation is to allow type-specific styling.  For example, we are making all shown fields bold, unless the field is a text field, in which case we use a normal font weight.

--Dan
